### PR TITLE
fix: make menu button color always black no matter what

### DIFF
--- a/public/scss/components/Header.module.scss
+++ b/public/scss/components/Header.module.scss
@@ -227,6 +227,9 @@
         overflow-x: hidden;
         overflow-y: hidden;
 
+        // Fix Safari issue
+        transform: translate3d(0, 0, 0);
+
         & ~ main,
         & ~ footer
         {

--- a/public/scss/components/Header.module.scss
+++ b/public/scss/components/Header.module.scss
@@ -411,6 +411,20 @@
             border: none;
             cursor: pointer;
 
+            &,
+            &:hover,
+            &:active,
+            &:focus,
+            &:focus-visible,
+            &:focus-within,
+            &:visited
+            {
+                outline: none;
+                color: $color_black;
+                box-shadow: 0 0 0 transparent;
+                border: none;
+            }
+
             svg
             {
                 @include fixedSize(24px);


### PR DESCRIPTION
Issue #58 

1. Button menu warnanya dibuat selalu hitam
2. Fix bug overlfow pada element fixed di Safari 